### PR TITLE
Fixing signature of al_compose_transform()

### DIFF
--- a/allegro5/transformations.d
+++ b/allegro5/transformations.d
@@ -21,7 +21,7 @@ extern (C)
 	void al_rotate_transform(ALLEGRO_TRANSFORM* trans, float theta);
 	void al_scale_transform(ALLEGRO_TRANSFORM* trans, float sx, float sy);
 	void al_transform_coordinates(in ALLEGRO_TRANSFORM* trans, float* x, float* y);
-	void al_compose_transform(in ALLEGRO_TRANSFORM* trans, ALLEGRO_TRANSFORM* trans2);
+	void al_compose_transform(ALLEGRO_TRANSFORM* trans, in ALLEGRO_TRANSFORM* trans2);
 	ALLEGRO_TRANSFORM* al_get_current_transform();
 	void al_invert_transform(ALLEGRO_TRANSFORM* trans);
 	int  al_check_inverse(in ALLEGRO_TRANSFORM* trans, float tol);


### PR DESCRIPTION
Unlike the other transform-related functions, with al_compose_transform() the first parameter is mutable and the second one is const. I just moved the 'in' from the first to the second parameter, so that it matches the C signature and becomes usable. (See http://alleg.sourceforge.net/a5docs/5.0.7/transformations.html#al_compose_transform )

(Nice bindings, BTW. Thanks for them!)
