### PR TITLE
Added functions. Renamed wrong named functions e.g. *_event to *_f

### DIFF
--- a/allegro5/allegro_font.d
+++ b/allegro5/allegro_font.d
@@ -42,6 +42,7 @@ extern (C)
 	ALLEGRO_FONT* al_load_font(in char* filename, int size, int flags);
 
 	ALLEGRO_FONT* al_grab_font_from_bitmap(ALLEGRO_BITMAP* bmp, int n, int ranges[]);
+	ALLEGRO_FONT* al_create_builtin_font();
 
 	void al_draw_ustr(in ALLEGRO_FONT* font, ALLEGRO_COLOR color, float x, float y, int flags, in ALLEGRO_USTR* ustr);
 	void al_draw_text(in ALLEGRO_FONT* font, ALLEGRO_COLOR color, float x, float y, int flags, in char* text);

--- a/allegro5/allegro_ttf.d
+++ b/allegro5/allegro_ttf.d
@@ -19,7 +19,10 @@ extern (C)
 	}
 
 	ALLEGRO_FONT* al_load_ttf_font(in char* filename, int size, int flags);
-	ALLEGRO_FONT* al_load_ttf_font_entry(ALLEGRO_FILE* file, in char* filename, int size, int flags);
+	ALLEGRO_FONT* al_load_ttf_font_f(ALLEGRO_FILE* file, in char* filename, int size, int flags);
+	ALLEGRO_FONT* al_load_ttf_font_stretch(in char* filename, int w, int h, int flags);
+	ALLEGRO_FONT* al_load_ttf_font_stretch_f(ALLEGRO_FILE *file, in char* filename, int w, int h, int flags);
+
 	bool al_init_ttf_addon();
 	void al_shutdown_ttf_addon();
 	uint al_get_allegro_ttf_version();


### PR DESCRIPTION
There was a few missing functions as of Allegro 5.0.8 that I have found.
Here is the patch for that.
As well as renaming a function (al_load_ttf_font_entry) to [al_load_ttf_font_f](https://www.allegro.cc/manual/5/al_load_ttf_font_f) as that is its correct name.
