### PR TITLE
fixed dmd 2.067 warnings: C-style to D-style array syntax

### DIFF
--- a/allegro5/allegro_primitives.d
+++ b/allegro5/allegro_primitives.d
@@ -106,8 +106,8 @@ extern (C)
 	void al_draw_elliptical_arc(float cx, float cy, float rx, float ry, float start_theta, float delta_theta, ALLEGRO_COLOR color, float thickness);
 	void al_draw_pieslice(float cx, float cy, float r, float start_theta, float delta_theta, ALLEGRO_COLOR color, float thickness);
 
-	void al_calculate_spline(float* dest, int stride, float points[8], float thickness, int num_segments);
-	void al_draw_spline(float points[8], ALLEGRO_COLOR color, float thickness);
+	void al_calculate_spline(float* dest, int stride, float[8] points, float thickness, int num_segments);
+	void al_draw_spline(float[8] points, ALLEGRO_COLOR color, float thickness);
 
 	void al_calculate_ribbon(float* dest, int dest_stride, in float *points, int points_stride, float thickness, int num_segments);
 	void al_draw_ribbon(in float *points, int points_stride, ALLEGRO_COLOR color, float thickness, int num_segments);

--- a/allegro5/events.d
+++ b/allegro5/events.d
@@ -69,7 +69,7 @@ extern (C)
 {
 	struct ALLEGRO_EVENT_SOURCE
 	{
-		int __pad[32] = void;
+		int[32] __pad = void;
 	}
 	
 	struct ALLEGRO_ANY_EVENT

--- a/allegro5/fixed.d
+++ b/allegro5/fixed.d
@@ -223,8 +223,8 @@ extern (C)
 		return cast(al_fixed)(0x00400000 - _al_fix_acos_tbl[(x+65536+127)>>8]);
 	}
 
-	
-	private const al_fixed _al_fix_cos_tbl[512] =
+
+	private const(al_fixed[512]) _al_fix_cos_tbl =
 	[
 		/* precalculated fixed point (16.16) cosines for a full circle (0-255) */
 
@@ -294,7 +294,7 @@ extern (C)
 		65220,  65294,  65358,  65413,  65457,  65492,  65516,  65531L
 	];
 
-	private const al_fixed _al_fix_tan_tbl[256] =
+	private const(al_fixed[256]) _al_fix_tan_tbl =
 	[
 		/* precalculated fixed point (16.16) tangents for a half circle (0-127) */
 
@@ -332,7 +332,7 @@ extern (C)
 		-6455,  -5644,  -4834,  -4026,  -3220,  -2414,  -1609,  -804L
 	];
 
-	private const al_fixed _al_fix_acos_tbl[513] =
+	private const(al_fixed[513]) _al_fix_acos_tbl =
 	[
 		/* precalculated fixed point (16.16) inverse cosines (-1 to 1) */
 

--- a/allegro5/joystick.d
+++ b/allegro5/joystick.d
@@ -15,10 +15,10 @@ extern (C)
 	{
 		struct STICK
 		{
-			float axis[_AL_MAX_JOYSTICK_AXES];        /* -1.0 to 1.0 */
+			float[_AL_MAX_JOYSTICK_AXES] axis;        /* -1.0 to 1.0 */
 		};
-		STICK stick[_AL_MAX_JOYSTICK_STICKS];
-		int button[_AL_MAX_JOYSTICK_BUTTONS];        /* 0 to 32767 */
+		STICK[_AL_MAX_JOYSTICK_STICKS] stick;
+		int[_AL_MAX_JOYSTICK_BUTTONS] button;        /* 0 to 32767 */
 	};
 
 	enum ALLEGRO_JOYFLAGS

--- a/allegro5/keyboard.d
+++ b/allegro5/keyboard.d
@@ -14,7 +14,7 @@ extern (C)
 		/* public */
 		ALLEGRO_DISPLAY* display;
 		/* internal */
-		uint __key_down__internal__[(ALLEGRO_KEY_MAX + 31) / 32]; 
+		uint[(ALLEGRO_KEY_MAX + 31) / 32] __key_down__internal__;
 	}
 	
 	bool  al_is_keyboard_installed();

--- a/allegro5/mouse.d
+++ b/allegro5/mouse.d
@@ -16,7 +16,7 @@ extern (C)
 		int y;
 		int z;
 		int w;
-		int more_axes[ALLEGRO_MOUSE_MAX_EXTRA_AXES];
+		int[ALLEGRO_MOUSE_MAX_EXTRA_AXES] more_axes;
 		int buttons;
 		float pressure;
 		ALLEGRO_DISPLAY* display;

--- a/allegro5/tls.d
+++ b/allegro5/tls.d
@@ -19,7 +19,7 @@ extern (C)
 	
 	struct ALLEGRO_STATE
 	{
-		char _tls[1024];
+		char[1024] _tls;
 	}
 
 	void al_store_state(ALLEGRO_STATE *state, int flags);


### PR DESCRIPTION
dmd version 2.067 gave several warnings of the form
"instead of C-style syntax, use D-style syntax 'float[8] points'",
all array declarations have been amended. Also using brackets
now for clarity in fixed.d: const(al_fixed[512]) _al_fix_cos_tbl.