### PR TITLE
ALLEGRO_ALIGN_INTEGER also in 5.0.x

### DIFF
--- a/allegro5/allegro_font.d
+++ b/allegro5/allegro_font.d
@@ -32,9 +32,11 @@ extern (C)
 
 	enum
 	{
-		ALLEGRO_ALIGN_LEFT   = 0,
-		ALLEGRO_ALIGN_CENTRE = 1,
-		ALLEGRO_ALIGN_RIGHT  = 2
+		ALLEGRO_ALIGN_LEFT       = 0,
+		ALLEGRO_ALIGN_CENTRE     = 1,
+		ALLEGRO_ALIGN_CENTER     = 1,
+		ALLEGRO_ALIGN_RIGHT      = 2,
+		ALLEGRO_ALIGN_INTEGER    = 4
 	}
 
 	bool al_register_font_loader(in char* ext, ALLEGRO_FONT* function(in char* filename, int size, int flags) load);


### PR DESCRIPTION
This enum from the 5.1 branch should be in 5.0.8 and later, too.