### PR TITLE
Reorder src/dest args in al_copy_transform.

### DIFF
--- a/allegro5/transformations.d
+++ b/allegro5/transformations.d
@@ -14,7 +14,7 @@ extern (C)
 
 	/* Transformations*/
 	void al_use_transform(in ALLEGRO_TRANSFORM* trans);
-	void al_copy_transform(in ALLEGRO_TRANSFORM* src, ALLEGRO_TRANSFORM* dest);
+	void al_copy_transform(ALLEGRO_TRANSFORM* dest, in ALLEGRO_TRANSFORM* src);
 	void al_identity_transform(ALLEGRO_TRANSFORM* trans);
 	void al_build_transform(ALLEGRO_TRANSFORM* trans, float x, float y, float sx, float sy, float theta);
 	void al_translate_transform(ALLEGRO_TRANSFORM* trans, float x, float y);


### PR DESCRIPTION
The proper signature is
al_copy_transform(ALLEGRO_TRANSFORM *dest, const ALLEGRO_TRANSFORM *src),
but the binding was declared as
al_copy_transform(in ALLEGRO_TRANSFORM *src, ALLEGRO_TRANSFORM *dest).

See: https://www.allegro.cc/manual/5/al_copy_transform

This makes sure the const specifier applies to the correct parameter and avoids
causing confusion when seeing the parameter names in error messages.