### PR TITLE
Fix warnings for deprecated import behavior.

### DIFF
--- a/allegro5/blender.d
+++ b/allegro5/blender.d
@@ -2,6 +2,7 @@ module allegro5.blender;
 
 import allegro5.color;
 import allegro5.internal.da5;
+static import allegro5.color_ret;
 
 extern(C)
 {

--- a/allegro5/file.d
+++ b/allegro5/file.d
@@ -4,6 +4,22 @@ import allegro5.internal.da5;
 import allegro5.path;
 import allegro5.utf8;
 
+version (Tango)
+{
+	import tango.core.Vararg : va_list;
+}
+else
+{
+	version(D_Version2)
+	{
+		import core.stdc.stdarg : va_list;
+	}
+	else
+	{
+		import std.c.stdarg : va_list;
+	}
+}
+
 version(Windows)
 {
 	private alias long off_t;


### PR DESCRIPTION
The language is cracking down on leaking imports, leading to the
following deprecation messages:

```
allegro5/file.d(100,6): Deprecation: allegro5.utf8.va_list is not
visible from module file

allegro5/blender.d-mixin-38(40,22): Deprecation: module
allegro5.color_ret is not accessible here, perhaps add 'static import
allegro5.color_ret;'
```

This fixes both of the above.