### PR TITLE
Run thread-local static constructors and destructors on Mac

### DIFF
--- a/allegro5/system.d
+++ b/allegro5/system.d
@@ -24,6 +24,9 @@ else
 	}
 }
 
+extern (C) void rt_moduleTlsCtor();
+extern (C) void rt_moduleTlsDtor();
+
 int al_run_allegro(scope int delegate() user_main)
 {
 	extern(C) static int main_runner(int argc, char** argv)
@@ -31,7 +34,10 @@ int al_run_allegro(scope int delegate() user_main)
 		version(OSX)
 		{
 			version(D_Version2)
+			{
 				thread_attachThis();
+				rt_moduleTlsCtor();
+			}
 			else
 				Thread.thread_attach();
 		}
@@ -41,7 +47,10 @@ int al_run_allegro(scope int delegate() user_main)
 		version(OSX)
 		{
 			version(D_Version2)
+			{
 				thread_detachThis();
+				rt_moduleTlsDtor();
+			}
 			else
 				Thread.thread_detach();
 		}


### PR DESCRIPTION
From the documentation on [`thread_attachThis`](https://dlang.org/phobos/core_thread.html#.thread_attachThis):

> __NOTE:__
> This routine does not run thread-local static constructors when called. If full functionality as a D thread is desired, the following function must be called after __thread_attachThis__:
>
> extern (C) void rt_moduleTlsCtor();

[`thread_detachThis`](https://dlang.org/phobos/core_thread.html#.thread_detachThis) has a similar note about calling `rt_moduleTlsDtor` after `thread_detachThis`.

This prevents bugs like the following: SimonN/LixD#121

__Note:__ I don't know whether the same should or can be done for the D v1 version with `Thread.thread_attach/detach` so I didn't touch it.