### PR TITLE
Mark asm nothrow @nogc to fix deprecation

### DIFF
--- a/allegro5/internal/da5.d
+++ b/allegro5/internal/da5.d
@@ -8,7 +8,7 @@ char[] ColorWrapper(in char[] prefix, in char[] func, in char[] arg_decls, in ch
 		auto ret = ` ~ prefix ~ func ~ `(` ~ arg_names ~ `);
 		version(ALLEGRO_SUB)
 		{
-			asm
+			asm nothrow @nogc
 			{
 				sub ESP, 4;
 			}


### PR DESCRIPTION
Windows DMD 2.080 encourages to mark asm statements in nothrow @nogc
functions also with nothrow @nogc. This fixes a deprecation warning.
There was no compiler error.

Linux doesn't need this asm and thus Linux builds were always
warning-free.