### PR TITLE
ColorWrapper is binding where able, not wrapper

### DIFF
--- a/allegro5/allegro_color.d
+++ b/allegro5/allegro_color.d
@@ -26,17 +26,8 @@ nothrow @nogc extern (C)
 	void al_color_rgb_to_html(float red, float green, float blue,  char* string);
 	void al_color_html_to_rgb(in char* string, float* red, float* green, float* blue);
 }
-	
-static import allegro5.allegro_color_ret;
 
-version(Windows)
-{
-	version(ALLEGRO_MSVC) {}
-	else
-	{
-		version = ALLEGRO_SUB;
-	}
-}
+static import allegro5.allegro_color_ret;
 
 mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_yuv", "float y, float u, float v", "y, u, v"));
 mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_cmyk", "float c, float m, float y, float k", "c, m, y, k"));

--- a/allegro5/bitmap.d
+++ b/allegro5/bitmap.d
@@ -6,7 +6,7 @@ import allegro5.internal.da5;
 nothrow @nogc extern (C)
 {
 	struct ALLEGRO_BITMAP {};
-	
+
 	/*
 	 * Bitmap flags
 	 */
@@ -25,7 +25,7 @@ nothrow @nogc extern (C)
 		ALLEGRO_VIDEO_BITMAP             = 0x0400,
 		ALLEGRO_CONVERT_BITMAP           = 0x1000
 	}
-	
+
 	void al_set_new_bitmap_format(int format);
 	void al_set_new_bitmap_flags(int flags);
 	int al_get_new_bitmap_format();
@@ -66,22 +66,6 @@ nothrow @nogc extern (C)
 	void al_convert_memory_bitmaps();
 }
 
-/*
- * MinGW 4.5 and below has a bizzare calling convention when returning
- * structs. These wrappers take care of the differences in calling convention.
- *
- * This issue does not exist in MSVC and maybe MinGW 4.6.
- */
-
 static import allegro5.color_ret;
-
-version(Windows)
-{
-	version(ALLEGRO_MSVC) {}
-	else
-	{
-		version = ALLEGRO_SUB;
-	}
-}
 
 mixin(ColorWrapper("allegro5.color_ret.", "al_get_pixel", "ALLEGRO_BITMAP* bitmap, int x, int y", "bitmap, x, y"));

--- a/allegro5/color.d
+++ b/allegro5/color.d
@@ -59,23 +59,7 @@ nothrow @nogc extern (C)
 	int al_get_pixel_block_height(int format);
 }
 
-/*
- * MinGW 4.5 and below has a bizzare calling convention when returning
- * structs. These wrappers take care of the differences in calling convention.
- *
- * This issue does not exist in MSVC and maybe MinGW 4.6.
- */
-
 static import allegro5.color_ret;
-
-version(Windows)
-{
-	version(ALLEGRO_MSVC) {}
-	else
-	{
-		version = ALLEGRO_SUB;
-	}
-}
 
 mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgb", "ubyte r, ubyte g, ubyte b", "r, g, b"));
 mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgba", "ubyte r, ubyte g, ubyte b, ubyte a", "r, g, b, a"));

--- a/allegro5/internal/da5.d
+++ b/allegro5/internal/da5.d
@@ -1,21 +1,69 @@
 module allegro5.internal.da5;
 
-char[] ColorWrapper(in char[] prefix, in char[] func, in char[] arg_decls, in char[] arg_names)
+/*
+ * Issue: MinGW 4.5 and below has a bizzare calling convention when
+ * returning structs. ColorWrapper takes care of the difference in
+ * calling convention. If this wrapper is necessary, then D programs
+ * that use DAllegro5 should link against allegro_color even when they
+ * never call any allegro_color function.
+ *
+ * The following toolchains (to compile Allegro DLLs) are free of this issue:
+ *  - MSVC,
+ *  - maybe MinGW 4.6.
+ * ColorWrapper resolves to a mere binding on all systems that don't
+ * need the caretaking, and allegro_color needs not be linked against
+ * then unless you call a function from allegro_color.
+ *
+ * ColorWrapper is private to DAllegro5. Call ColorWrapper in DAllegro5
+ * outside any "nothrow @nogc extern (C)" because ColorWrapper will
+ * insert attributes itself.
+ */
+char[] ColorWrapper(
+	in char[] prefix, in char[] func, in char[] arg_decls, in char[] arg_names)
 {
-	return
-	`nothrow @nogc ALLEGRO_COLOR ` ~ func ~ `(` ~ arg_decls ~ `)
+	static if (needsMinGW4CallingConvention)
 	{
-		auto ret = ` ~ prefix ~ func ~ `(` ~ arg_names ~ `);
-		version(ALLEGRO_SUB)
-		{
-			asm nothrow @nogc
+		// Implement a new D function to wrap Allegro's C function,
+		// fixing the calling convention (see comment for ColorWrapper above).
+		return
+			`nothrow @nogc ALLEGRO_COLOR ` ~ func ~ `(` ~ arg_decls ~ `)
 			{
-				sub ESP, 4;
-			}
-		}
-		return ret;
-	}`;
+				auto ret = ` ~ prefix ~ func ~ `(` ~ arg_names ~ `);
+				asm nothrow @nogc
+				{
+					sub ESP, 4;
+				}
+				return ret;
+			}`;
+	}
+	else
+	{
+		// Declare function as a normal C binding.
+		return
+			`nothrow @nogc extern (C)
+			ALLEGRO_COLOR ` ~ func ~ `(` ~ arg_decls ~ `);`;
+	}
 }
+
+bool needsMinGW4CallingConvention() pure nothrow @nogc
+{
+	version(Windows)
+	{
+		version(ALLEGRO_MSVC)
+		{
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+	else
+	{
+		return false;
+	}
+}
+
 
 version(D_Version2)
 	mixin(`alias const(char) const_char;`);


### PR DESCRIPTION
If ColorWrapper is a binding, not a wrapper, then most systems do not
have to link against an unneeded addon allegro_color.

This does not change which versions get the MinGW calling convention.
It merely gives every other version cleaner bindings. Even though
it's not a pure refactoring (usercode will now call C functions
instead of D functions), it should not change any high-level
semantics or break usercode. Tested on DMD 32 Win, LDC 64 Win,
DMD 64 Linux, LDC 64 Linux.

Uses 'static if' instead of declaring version ALLEGRO_SUB.
Refactors all version checks into one file for DRY.