### PR TITLE
Change ColorWrapper and _AL_EVENT_HEADER so that they are compatible with BetterC

### DIFF
--- a/allegro5/allegro_color.d
+++ b/allegro5/allegro_color.d
@@ -29,10 +29,10 @@ nothrow @nogc extern (C)
 
 static import allegro5.allegro_color_ret;
 
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_yuv", "float y, float u, float v", "y, u, v"));
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_cmyk", "float c, float m, float y, float k", "c, m, y, k"));
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_hsl", "float h, float s, float l", "h, s, l"));
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_hsv", "float h, float s, float v", "h, s, v"));
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_name", "in char* name", "name"));
-mixin(ColorWrapper("allegro5.allegro_color_ret.", "al_color_html", "in char* string", "string"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_yuv", "float y, float u, float v", "y, u, v"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_cmyk", "float c, float m, float y, float k", "c, m, y, k"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_hsl", "float h, float s, float l", "h, s, l"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_hsv", "float h, float s, float v", "h, s, v"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_name", "in char* name", "name"));
+mixin(ColorWrapper!("allegro5.allegro_color_ret.", "al_color_html", "in char* string", "string"));
 

--- a/allegro5/bitmap.d
+++ b/allegro5/bitmap.d
@@ -68,4 +68,4 @@ nothrow @nogc extern (C)
 
 static import allegro5.color_ret;
 
-mixin(ColorWrapper("allegro5.color_ret.", "al_get_pixel", "ALLEGRO_BITMAP* bitmap, int x, int y", "bitmap, x, y"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_get_pixel", "ALLEGRO_BITMAP* bitmap, int x, int y", "bitmap, x, y"));

--- a/allegro5/blender.d
+++ b/allegro5/blender.d
@@ -37,4 +37,4 @@ nothrow @nogc extern(C)
 	void al_get_separate_blender(int* op, int* source, int* dest, int *alpha_op, int* alpha_src, int* alpha_dest);
 }
 
-mixin(ColorWrapper("allegro5.color_ret.", "al_get_blend_color", "", ""));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_get_blend_color", "", ""));

--- a/allegro5/color.d
+++ b/allegro5/color.d
@@ -61,9 +61,9 @@ nothrow @nogc extern (C)
 
 static import allegro5.color_ret;
 
-mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgb", "ubyte r, ubyte g, ubyte b", "r, g, b"));
-mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgba", "ubyte r, ubyte g, ubyte b, ubyte a", "r, g, b, a"));
-mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgb_f", "float r, float g, float b", "r, g, b"));
-mixin(ColorWrapper("allegro5.color_ret.", "al_map_rgba_f", "float r, float g, float b, float a", "r, g, b, a"));
-mixin(ColorWrapper("allegro5.color_ret.", "al_premul_rgba", "ubyte r, ubyte g, ubyte b, ubyte a", "r, g, b, a"));
-mixin(ColorWrapper("allegro5.color_ret.", "al_premul_rgba_f", "float r, float g, float b, float a", "r, g, b, a"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_map_rgb", "ubyte r, ubyte g, ubyte b", "r, g, b"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_map_rgba", "ubyte r, ubyte g, ubyte b, ubyte a", "r, g, b, a"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_map_rgb_f", "float r, float g, float b", "r, g, b"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_map_rgba_f", "float r, float g, float b, float a", "r, g, b, a"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_premul_rgba", "ubyte r, ubyte g, ubyte b, ubyte a", "r, g, b, a"));
+mixin(ColorWrapper!("allegro5.color_ret.", "al_premul_rgba_f", "float r, float g, float b, float a", "r, g, b, a"));

--- a/allegro5/events.d
+++ b/allegro5/events.d
@@ -71,7 +71,7 @@ ALLEGRO_EVENT_TYPE ALLEGRO_GET_EVENT_TYPE(char a, char b, char c, char d)
 	return AL_ID(a, b, c, d);
 }
 
-package char[] _AL_EVENT_HEADER(in char[] src_type)
+package string _AL_EVENT_HEADER(string src_type)()
 {
 	return "ALLEGRO_EVENT_TYPE type;" ~ src_type ~ "* source; double timestamp;";
 }
@@ -85,12 +85,12 @@ nothrow @nogc extern (C)
 	
 	struct ALLEGRO_ANY_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_EVENT_SOURCE"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_EVENT_SOURCE"));
 	}
 	
 	struct ALLEGRO_DISPLAY_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_DISPLAY"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_DISPLAY"));
 		int x, y;
 		int width, height;
 		int orientation;
@@ -98,7 +98,7 @@ nothrow @nogc extern (C)
 
 	struct ALLEGRO_JOYSTICK_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_JOYSTICK"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_JOYSTICK"));
 		ALLEGRO_JOYSTICK* id;
 		int stick;
 		int axis;
@@ -108,7 +108,7 @@ nothrow @nogc extern (C)
 
 	struct ALLEGRO_KEYBOARD_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_KEYBOARD"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_KEYBOARD"));
 		ALLEGRO_DISPLAY* display;  /* the window the key was pressed in */
 		int keycode;               /* the physical key pressed */
 		int unichar;               /* unicode character or negative */
@@ -118,7 +118,7 @@ nothrow @nogc extern (C)
 
 	struct ALLEGRO_MOUSE_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_MOUSE"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_MOUSE"));
 		ALLEGRO_DISPLAY* display;
 		/* (display) Window the event originate from */
 		/* (x, y) Primary mouse position */
@@ -132,14 +132,14 @@ nothrow @nogc extern (C)
 
 	struct ALLEGRO_TIMER_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_TIMER"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_TIMER"));
 		long count;
 		double error;
 	}
 	
 	struct ALLEGRO_TOUCH_EVENT
 	{
-	   mixin(_AL_EVENT_HEADER("ALLEGRO_TOUCH_INPUT"));
+	   mixin(_AL_EVENT_HEADER!("ALLEGRO_TOUCH_INPUT"));
 	   ALLEGRO_DISPLAY* display;
 	   /* (id) Identifier of the event, always positive number.
 		* (x, y) Touch position on the screen in 1:1 resolution.
@@ -156,7 +156,7 @@ nothrow @nogc extern (C)
 
 	struct ALLEGRO_USER_EVENT
 	{
-		mixin(_AL_EVENT_HEADER("ALLEGRO_EVENT_SOURCE"));
+		mixin(_AL_EVENT_HEADER!("ALLEGRO_EVENT_SOURCE"));
 		ALLEGRO_USER_EVENT_DESCRIPTOR* __internal__descr;
 		intptr_t data1;
 		intptr_t data2;

--- a/allegro5/internal/da5.d
+++ b/allegro5/internal/da5.d
@@ -18,8 +18,7 @@ module allegro5.internal.da5;
  * outside any "nothrow @nogc extern (C)" because ColorWrapper will
  * insert attributes itself.
  */
-char[] ColorWrapper(
-	in char[] prefix, in char[] func, in char[] arg_decls, in char[] arg_names)
+string ColorWrapper(string prefix, string func, string arg_decls, string arg_names)()
 {
 	static if (NeedsMinGW4CallingConvention)
 	{


### PR DESCRIPTION
ColorWrapper and _AL_EVENT_HEADER use array concatenation on strings, which is not compatible with BetterC because it requires GC. However, both functions are only ever used to generate strings for mixins, so their arguments are never dynamic. I edited them to take their arguments as template parameters so that the project can be compiled with the --betterC option.