### PR TITLE
Add platform-specific support: Windows and X

### DIFF
--- a/allegro5/allegro_windows.d
+++ b/allegro5/allegro_windows.d
@@ -1,0 +1,30 @@
+module allegro5.allegro_windows;
+
+import allegro5.display;
+import core.sys.windows.windows;
+
+nothrow @nogc extern (C) {
+    HWND al_get_win_window_handle(ALLEGRO_DISPLAY*);
+
+    bool al_win_add_window_callback(
+        ALLEGRO_DISPLAY* display,
+        bool function(
+            ALLEGRO_DISPLAY* display,
+            uint message,
+            WPARAM wparam,
+            LPARAM lparam,
+            LRESULT* result,
+            void* userdata) callback,
+        void* userdata);
+
+    bool al_win_remove_window_callback(
+        ALLEGRO_DISPLAY* display,
+        bool function(
+            ALLEGRO_DISPLAY* display,
+            uint message,
+            WPARAM wparam,
+            LPARAM lparam,
+            LRESULT* result,
+            void* userdata) callback,
+        void* userdata);
+}

--- a/allegro5/allegro_x.d
+++ b/allegro5/allegro_x.d
@@ -1,0 +1,18 @@
+module allegro5.allegro_x;
+
+import allegro.bitmap;
+import allegro.display;
+
+nothrow @nogc extern (C) {
+    /*
+     * The correct return type of al_get_x_window_id is XID. For C, XID is
+     * defined in <X11/Xdefs.h> or <X11/X.h> as a 32-bit unsigned integer,
+     * either C's unsigned long (if that is 32 bits long) or C's unsigned int.
+     *
+     * Since there seem to be no canonical D bindings for the X Window System,
+     * we hardcode al_get_x_window_id's return type as D's 32-bit uint.
+     */
+    uint al_get_x_window_id(ALLEGRO_DISPLAY*);
+
+    bool al_x_set_initial_icon(ALLEGRO_BITMAP*);
+}


### PR DESCRIPTION
This adds bindings for [Allegro 5's platform-specific functions](https://liballeg.org/a5docs/trunk/platform.html) for Windows and the X Window System to DAllegro5.

(This does not add any Mac OS X bindings nor Iphone bindings, and it does not touch the Android bindings. DAllegro5 binds 4 of the 6 Android-specific A5 functions.)

So far, I've thought about where to place these new files and how to name them as D modules. I've also chosen parameter types and return types as sensible as I could. E.g., for that lone X-specific function that wants the X-specific type `XID`, I researched what `XID` can ever be in C, and I use D's `uint` instead of requiring a dedicated X header bindings.

**This code is UNTESTED. Don't merge yet!** Windows is only partly tested: Forward-declaring `HWND al_get_win_window_handle(ALLEGRO_DISPLAY*);` works with my `import core.sys.windows.windows`, but I haven't tested any other functions. For X, I haven't tested anything yet. I'll see when I find time to test all of these functions.